### PR TITLE
Update motion to use VCR control

### DIFF
--- a/Marlin-CNC-Pendant/Marlin-CNC-Pendant.ino
+++ b/Marlin-CNC-Pendant/Marlin-CNC-Pendant.ino
@@ -12,8 +12,8 @@
  ***/
 
 // Development and release version - Don't forget to update the changelog!!
-#define VERSION "V1.0-Alpha"
-#define BUILD "19123001"
+#define VERSION "V1.0-Beta"
+#define BUILD "19123002.VCR"
 
 
 

--- a/docs/changelog
+++ b/docs/changelog
@@ -1,4 +1,5 @@
-19122801 - Added C/R low pass filter and tweaked move values
+19123002.VCR - VCR Control branch initial commit
+19123001 - Added C/R low pass filter and tweaked move values
 		 - Changed speed multipliers for fixed speed values
 		 - Added usage explaination and comments
 19122801 - Added X10 / X100 output smoothing

--- a/docs/changelog
+++ b/docs/changelog
@@ -1,3 +1,5 @@
+19123003.VCR - VCR control added
+			 - Tested and working
 19123002.VCR - VCR Control branch initial commit
 19123001 - Added C/R low pass filter and tweaked move values
 		 - Changed speed multipliers for fixed speed values


### PR DESCRIPTION
Replaced  R/C output control with MCP4151 voltage controlled resistors (VCRs). 

Motion now much more stable and transient spikes resulting in unwanted motion now eliminated